### PR TITLE
Control transfer order

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,7 @@ options:
                         Number of simultaneous transfers
   -s SRC, --src SRC     Source directory
   -d DEST, --dest DEST  Destination directory
+  -a, --ascending       Transfer directories in ascending order by directory name (default is descending order)
+  --before BEFORE       Transfer directories whose names are lexicographically before BEFORE
+  --after AFTER         Transfer directories whose names are lexicographically after AFTER
 ```

--- a/sync-dirs.py
+++ b/sync-dirs.py
@@ -103,8 +103,8 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--src', help="Source directory")
     parser.add_argument('-d', '--dest', help="Destination directory")
     parser.add_argument('-a', '--ascending', action='store_true', help="Transfer directories in ascending order by directory name (default is descending order)")
-    parser.add_argument('--before', help="")
-    parser.add_argument('--after', help="")
+    parser.add_argument('--before', help="Transfer directories whose names are lexicographically before BEFORE")
+    parser.add_argument('--after', help="Transfer directories whose names are lexicographically after AFTER")
     args = parser.parse_args()
     
     main(args)

--- a/sync-dirs.py
+++ b/sync-dirs.py
@@ -53,7 +53,8 @@ def list_dirs_remote(src):
     client.connect(hostname=src_hostname, username=username, key_filename=os.path.expanduser('~/.ssh/id_rsa') )
     command = ' '.join(['ls', '-1', src_dir])
     stdin , stdout, stderr = client.exec_command(command)
-    transfer_dirs = list(filter(lambda x: x != "", stdout.read().decode('UTF-8').split('\n')))
+    transfer_dirs = stdout.read().decode('UTF-8').split('\n')
+    transfer_dirs = list(filter(lambda x: x != "", transfer_dirs))
 
     return transfer_dirs
 
@@ -77,6 +78,13 @@ def main(args):
     else:
         transfer_dirs = list_dirs_local(args.src)
 
+    if args.ascending:
+        transfer_dirs = sorted(transfer_dirs, reverse=False)
+    else:
+        transfer_dirs = sorted(transfer_dirs, reverse=True)
+
+    print(json.dumps(transfer_dirs, indent=2))
+    exit(0)
 
     with multiprocessing.Pool(processes=args.processes) as pool:
         transfers = list(zip(transfer_dirs, itertools.cycle([args.src]), itertools.cycle([args.dest])))
@@ -88,6 +96,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--processes', type=int, default=4, help="Number of simultaneous transfers")
     parser.add_argument('-s', '--src', help="Source directory")
     parser.add_argument('-d', '--dest', help="Destination directory")
+    parser.add_argument('-a', '--ascending', action='store_true', help="Transfer directories in ascending order by directory name (default is descending order)")
     args = parser.parse_args()
     
     main(args)

--- a/sync-dirs.py
+++ b/sync-dirs.py
@@ -83,6 +83,12 @@ def main(args):
     else:
         transfer_dirs = sorted(transfer_dirs, reverse=True)
 
+    if args.before:
+        transfer_dirs = list(filter(lambda x: x[0:len(args.before)] < args.before, transfer_dirs))
+
+    if args.after:
+        transfer_dirs = list(filter(lambda x: x[0:len(args.after)] > args.after, transfer_dirs))
+        
     print(json.dumps(transfer_dirs, indent=2))
     exit(0)
 
@@ -97,6 +103,8 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--src', help="Source directory")
     parser.add_argument('-d', '--dest', help="Destination directory")
     parser.add_argument('-a', '--ascending', action='store_true', help="Transfer directories in ascending order by directory name (default is descending order)")
+    parser.add_argument('--before', help="")
+    parser.add_argument('--after', help="")
     args = parser.parse_args()
     
     main(args)


### PR DESCRIPTION
Fixes #1 

Added new flags:

`--ascending`: When enabled, transfers are done in ascending lexicographic order by directory name. Otherwise done in descending order, by default.
`--after`: Specify a string for the least lexicographic directory name to be transferred
`--before`: Specify a string for the greatest lexicographic directory name to be transferred.